### PR TITLE
Orgify: Move all relevant tally.cash references to tallyho.org

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
   siteMetadata: {
     title: `Tally Ho — The community owned & operated wallet`,
     description: ``,
-    image: `https://tally.cash/cover.png`, // Twitter wants an absolute rather than relative url.
+    image: `https://tallyho.org/cover.png`, // Twitter wants an absolute rather than relative url.
     author: `@thesis_co`,
   },
   plugins: [
@@ -36,7 +36,7 @@ module.exports = {
       options: {
         siteId: "1",
         matomoUrl: "https://tallycash.matomo.cloud",
-        siteUrl: "https://tally.cash",
+        siteUrl: "https://tallyho.org",
       },
     },
     {

--- a/manifesto-dapp-backend/functions/src/index.ts
+++ b/manifesto-dapp-backend/functions/src/index.ts
@@ -280,7 +280,7 @@ async function verifyToken(token: SignedMessage) {
   }
 
   if (
-    !["tally.cash", "localhost:8000"].includes(verified.domain) &&
+    !["tallyho.org","tally.cash", "localhost:8000"].includes(verified.domain) &&
     !verified.domain.endsWith("tally-cash.netlify.app")
   ) {
     throw new HttpsError("invalid-argument", "Wrong domain", "Wrong domain");
@@ -288,6 +288,7 @@ async function verifyToken(token: SignedMessage) {
 
   if (
     [
+      "https://tallyho.org/web3pledge",
       "https://tally.cash/web3pledge",
       "https://localhost:8000/web3pledge",
     ].includes(verified.uri)

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "tally.cash",
+  "name": "tallyho.org",
   "version": "1.0.0",
   "private": true,
-  "description": "tally.cash",
-  "author": "Matt Luongo <mhluongo@gmail.com>",
-  "repository": "git@github.com:thesis/tally.cash.git",
+  "description": "tallyho.org",
+  "author": "Tally Ho Doggos <doggos@tallyho.org>",
+  "repository": "git@github.com:thesis/tallyho.org.git",
   "license": "MIT",
   "keywords": [
     "ethereum",

--- a/src/features/Dao/GetInvolved/index.tsx
+++ b/src/features/Dao/GetInvolved/index.tsx
@@ -71,14 +71,14 @@ export function DaoGetInvolved() {
       >
         <Option
           iconSrc={require("./option-1-discord.svg")}
-          href="https://chat.tally.cash/"
+          href="https://chat.tallyho.org/"
           title="Discord"
         >
           The best way to get started and join the community.
         </Option>
         <Option
           iconSrc={require("./option-2-gov.svg")}
-          href="https://gov.tally.cash/"
+          href="https://gov.tallyho.org/"
           title="Governance Forum"
         >
           Our governance forum. A place for sharing governance ideas and

--- a/src/features/Dao/Hero/index.tsx
+++ b/src/features/Dao/Hero/index.tsx
@@ -73,7 +73,7 @@ export function DaoHero() {
               background-color: ${buttonBackgroundSemanticSuccess};
               margin: 4rem 0;
             `}
-            href="https://chat.tally.cash"
+            href="https://chat.tallyho.org"
             target="_blank"
           >
             Join Discord

--- a/src/features/Dao/Timeline/index.tsx
+++ b/src/features/Dao/Timeline/index.tsx
@@ -98,7 +98,7 @@ export function DaoTimeline() {
               <Event date="September 2021">First Community POAPs created</Event>
               <Event
                 date="December 2021"
-                href="https://gov.tally.cash/t/tally-ho-delegate-applications/18"
+                href="https://gov.tallyho.org/t/tally-ho-delegate-applications/18"
               >
                 Call for DAO Delegates (still open!)
               </Event>
@@ -116,7 +116,7 @@ export function DaoTimeline() {
               </Event>
               <Event
                 date="May 2022"
-                href="https://gov.tally.cash/t/tally-ho-dao-structure-proposal/455"
+                href="https://gov.tallyho.org/t/tally-ho-dao-structure-proposal/455"
               >
                 DAO Structure Proposed
               </Event>

--- a/src/features/Footer/Nav/index.tsx
+++ b/src/features/Footer/Nav/index.tsx
@@ -45,7 +45,7 @@ export function FooterNav() {
         <NavLink to="/security">Security</NavLink>
         <NavLink to="/dao">DAO</NavLink>
         <NavLink to="https://chrome.google.com/webstore/detail/tally-ho/eajafomhmkipbjmfmhebemolkcicgfmd">Download</NavLink>
-        <NavLink blank to="https://gov.tally.cash/">
+        <NavLink blank to="https://gov.tallyho.org/">
           Governance
         </NavLink>
         <NavLink blank to="https://docs.tally.cash/">
@@ -58,7 +58,7 @@ export function FooterNav() {
           Jobs
         </NavLink>
         <SocialLink
-          href="https://chat.tally.cash"
+          href="https://chat.tallyho.org"
           icon={{
             width: `24px`,
             height: `24px`,

--- a/src/features/Manifesto/ManifestoBody/index.tsx
+++ b/src/features/Manifesto/ManifestoBody/index.tsx
@@ -96,7 +96,7 @@ export function ManifestoBody() {
         Now imagine a community-owned wallet that actually embodies and protects
         Web3 values—a wallet that&rsquo;s available to anyone, anywhere on
         Earth, that can finance itself,{" "}
-        <a href="https://tally.cash/dao/" target="_blank">
+        <a href="https://tallyho.org/dao/" target="_blank">
           that&rsquo;s governed by a DAO
         </a>
         , and that&rsquo;s accountable to you, not some faceless corporation.

--- a/src/features/Manifesto/ManifestoPanel/ManifestoPanelSigned/ClaimDiscordRole.tsx
+++ b/src/features/Manifesto/ManifestoPanel/ManifestoPanelSigned/ClaimDiscordRole.tsx
@@ -147,7 +147,7 @@ export function ClaimDiscordRole({ account }: { account: FullAccount }) {
                   color: ${linkDarkTrophyGold};
                 }
               `}
-              to="https://chat.tally.cash/"
+              to="https://chat.tallyho.org/"
               target="_blank"
             >
               join our Discord ↗︎︎︎

--- a/src/features/Manifesto/index.tsx
+++ b/src/features/Manifesto/index.tsx
@@ -31,7 +31,7 @@ export function Manifesto() {
           description={
             "Sign to join our community & be eligible for future surprises"
           }
-          metaImage="https://tally.cash/web3pledge-cover.png"
+          metaImage="https://tallyho.org/web3pledge-cover.png"
         />
 
         <Header />

--- a/src/pages/ccpa.mdx
+++ b/src/pages/ccpa.mdx
@@ -107,7 +107,7 @@ We may deny your deletion request if retaining the information is necessary for 
 
 To exercise the access, data portability, and deletion rights described above, please submit a verifiable consumer request to us by either:
 
-- Emailing us at: privacy@tally.cash.
+- Emailing us at: privacy@tallyho.org.
 
 Only you, or a person registered with the California Secretary of State that you authorize to act on your behalf, may make a verifiable consumer request related to your personal information. You may also make a verifiable consumer request on behalf of your minor child.
 
@@ -157,4 +157,4 @@ Talley Wallet reserves the right to amend this privacy notice at our discretion 
 
 If you have any questions or comments about this notice, the ways in which Talley Wallet collects and uses your information, your choices and rights regarding such use, or wish to exercise your rights under California law, please do not hesitate to contact us at:
 
-**Email**: privacy@tally.cash
+**Email**: privacy@tallyho.org

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -255,7 +255,7 @@ Your rights may vary depending on where you are located. We have created mechani
   - Withdraw consent at any time where we are relying on consent to process your personal data. However, this will not affect the lawfulness of any processing carried out before you withdraw your consent. If you withdraw your consent, we may not be able to provide certain products or services to you. We will advise you if this is the case at the time you withdraw your consent. You acknowledge you cannot withdraw consent from participating in a smart contract that has already been executed.
   - We may make automated decisions about you based on your personal information that may affect your access or services provided to you. You have the right not to be subject the automated decision making so long as the decision is not necessary for the performance of the contract with you or required by legal obligation. If the decision making is necessary, you may contest the decision and request human intervention in the decision-making process.
   - You also have a right to lodge a complaint with the relevant Data Protection Authority.
-  - If you are in the European Economic Area (“EEA”), your request may be emailed to gdpr@tally.cash.
+  - If you are in the European Economic Area (“EEA”), your request may be emailed to gdpr@tallyho.org.
 
 <h2 id="InternationalTransfers">12. International Transfers</h2>
 
@@ -281,4 +281,4 @@ We will post any changes we may make to our privacy policy on this page. If the 
 
 <h2 id="ContactUs">16. Contact Us</h2>
 
-If you have any comments or questions about our privacy policy, please contact our data privacy manager at privacy@tally.cash.
+If you have any comments or questions about our privacy policy, please contact our data privacy manager at privacy@tallyho.org.

--- a/src/shared/seo.tsx
+++ b/src/shared/seo.tsx
@@ -6,7 +6,7 @@ function SEO({
   lang = `en`,
   meta = [],
   title,
-  metaImage = `https://tally.cash/cover.png`,
+  metaImage = `https://tallyho.org/cover.png`,
 }: {
   description?: string;
   lang?: string;


### PR DESCRIPTION
To be checked: is the manifest dApp backend auto-deployed, or do we need to deploy manually?

blog.* and doc.* domains are left as-is for now.